### PR TITLE
have a factory method to create a reporter-builder

### DIFF
--- a/leafy-metrics/README.md
+++ b/leafy-metrics/README.md
@@ -111,25 +111,33 @@ in all examples below ```metrics = Leafy::Metrics::Registry.new```
 ### console reporter
 
     require 'leafy/metrics/console_reporter'
-    reporter = Leafy::Metrics::ConsoleReporter.for_registry( metrics ).build
+    reporter = metrics.reporter_builder( Leafy::Metrics::ConsoleReporter ).build
 	reporter.start( 1, Leafy::Metrics::Reporter::SECONDS )
 	....
 	reporter.stop
 
 or with all the possible configuration
 
-	reporter = Leafy::Metrics::ConsoleReporter.for_registry( metrics )
+	reporter =  metrics.reporter_builder( Leafy::Metrics::ConsoleReporter )
 	    .convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
         .convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
         .output_to( STDERR )
         .build
+
+or the config via a block
+
+	reporter =  metrics.reporter_builder( Leafy::Metrics::ConsoleReporter ) do
+	  convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      output_to( STDERR )
+	end.build
 
 ### csv reporter
 
 for each metric there will be a CSV file inside a given directory
 
     require 'leafy/metrics/csv_reporter'
-    reporter = Leafy::Metrics::CSVReporter.for_registry( metrics )
+    reporter = metrics.reporter_builder( Leafy::Metrics::CSVReporter )
 	    .build( 'metrics/directory' )
 	reporter.start( 1, Leafy::Metrics::Reporter::SECONDS )
 	....
@@ -137,10 +145,17 @@ for each metric there will be a CSV file inside a given directory
 
 or with all possible configuration
 
-	reporter = Leafy::Metrics::CSVReporter.for_registry( metrics )
+	reporter = metrics.reporter_builder( Leafy::Metrics::CSVReporter )
 	    .convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
         .convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
         .build( 'metrics/directory' )
+
+or configuration via block
+
+	reporter = metrics.reporter_builder( Leafy::Metrics::CSVReporter ) do
+	  convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+    end.build( 'metrics/directory' )
 
 ### graphite reporter
 
@@ -153,19 +168,42 @@ there are three targets where to send the data
 the latter is collecting a few report event and sends them as batch. the ```sender``` is one of the above targets.
 
     require 'leafy/metrics/graphite_reporter'
-    reporter = Leafy::Metrics::GraphiteReporter.for_registry( metrics )
-	    .build( sender )
+    reporter = metrics.reporter_builder( Leafy::Metrics::GraphiteReporter )
+	    .build_tcp( hostname, port )
 	reporter.start( 1, Leafy::Metrics::Reporter::SECONDS )
 	....
 	reporter.stop
 
 or with full configuration
 
-	reporter = Leafy::Metrics::GraphiteReporter.for_registry( metrics )
+	reporter = metrics.reporter_builder( Leafy::Metrics::GraphiteReporter )
 	    .convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
         .convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
 		.prefixed_with( 'myapp' )
         .build( sender )
+
+or with block configuration
+
+	reporter = metrics.reporter_builder( Leafy::Metrics::GraphiteReporter ) do
+	  convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+	  prefixed_with( 'myapp' )
+    end.build_udp( host, port )
+
+### any third party reporter
+
+	reporter = metrics.reporter_builder( com.readytalk.metrics.StatsDReporter ) do
+	  convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+    end.build( host, port )
+
+or using the Java module reference
+
+	reporter = metrics.reporter_builder( Java::ComReadytalkMetrics::StatsDReporter ) do
+	  convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+      prefixed_with( 'app' )
+    end.build( host, port )
 
 ## developement
 

--- a/leafy-metrics/lib/leafy/metrics/graphite/graphite_reporter.rb
+++ b/leafy-metrics/lib/leafy/metrics/graphite/graphite_reporter.rb
@@ -20,6 +20,18 @@ module Leafy
         def build( graphite )
           Reporter.new( @builder.build( graphite.sender ) )
         end
+
+        def build_tcp( host, port )
+          build( Leafy::Metrics::Graphite.new_tcp( host, port ) )
+        end
+
+        def build_udp( host, port )
+          build( Leafy::Metrics::Graphite.new_udp( host, port ) )
+        end
+
+        def build_pickled( host, port )
+          build( Leafy::Metrics::Graphite.new_pickled( host, port ) )
+        end
       end
 
       def self.for_registry( metrics )

--- a/leafy-metrics/lib/leafy/metrics/registry.rb
+++ b/leafy-metrics/lib/leafy/metrics/registry.rb
@@ -91,6 +91,12 @@ module Leafy
       def remove( name )
         @metrics.remove( name )
       end
+
+      def reporter_builder( clazz, &block )
+        r = clazz.for_registry( @metrics )
+        r.instance_eval( &block ) if block
+        r
+      end
     end
   end
 end

--- a/leafy-metrics/lib/leafy/metrics/reporter.rb
+++ b/leafy-metrics/lib/leafy/metrics/reporter.rb
@@ -28,7 +28,10 @@ module Leafy
 
       class Builder
         def initialize( reporter_class, metrics )
-          @builder = reporter_class.for_registry( metrics.metrics )
+          # stay backward compatible
+          # FIXME remove for first proper release
+          metrics = metrics.metrics if metrics.is_a?( Leafy::Metrics::Registry )
+          @builder = reporter_class.for_registry( metrics )
           self
         end
         

--- a/leafy-metrics/spec/graphite_reporter_spec.rb
+++ b/leafy-metrics/spec/graphite_reporter_spec.rb
@@ -16,33 +16,53 @@ describe Leafy::Metrics::GraphiteReporter do
       it 'run reporter with defaults' do
         log = File.read( logfile )
         begin
-          reporter = subject.for_registry( metrics ).build( graphite )
+          reporter = metrics.reporter_builder( subject ).build( graphite )
           requests.mark
           reporter.start( 10, Leafy::Metrics::Reporter::MILLISECONDS )
           sleep 0.02
           reporter.stop
           result = File.read( logfile )[ (log.size)..-1 ]
-          expect( result ).to match /metrics-graphite-reporter-.-thread-1] WARN com.codahale.metrics.graphite.GraphiteReporter/
+          expect( result ).to match /metrics-graphite-reporter-.+-thread-1] WARN com.codahale.metrics.graphite.GraphiteReporter/
         ensure
           reporter.stop if reporter
         end
       end
 
-      it 'run reporter' do
+      it 'run reporter via builder config' do
         log = File.read( logfile )
         begin
-          reporter = subject.for_registry( metrics )
+          reporter = metrics.reporter_builder( subject )
             .convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
             .convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
             .prefixed_with( 'myapp' )
             .build( graphite )
-      
+
           requests.mark
           reporter.start( 10, Leafy::Metrics::Reporter::MILLISECONDS )
           sleep 0.02
-          reporter.stop 
+          reporter.stop
           result = File.read( logfile )[ (log.size)..-1 ]
-          expect( result ).to match /metrics-graphite-reporter-.-thread-1] WARN com.codahale.metrics.graphite.GraphiteReporter/
+          expect( result ).to match /metrics-graphite-reporter-.+-thread-1] WARN com.codahale.metrics.graphite.GraphiteReporter/
+        ensure
+          reporter.stop if reporter
+        end
+      end
+
+      it 'run reporter via block config' do
+        log = File.read( logfile )
+        begin
+          reporter = metrics.reporter_builder( subject ) do
+            convert_rates_to( Leafy::Metrics::Reporter::MILLISECONDS )
+            convert_durations_to( Leafy::Metrics::Reporter::MILLISECONDS )
+            prefixed_with( 'myapp' )
+          end.build( graphite )
+
+          requests.mark
+          reporter.start( 10, Leafy::Metrics::Reporter::MILLISECONDS )
+          sleep 0.02
+          reporter.stop
+          result = File.read( logfile )[ (log.size)..-1 ]
+          expect( result ).to match /metrics-graphite-reporter-.+-thread-1] WARN com.codahale.metrics.graphite.GraphiteReporter/
         ensure
           reporter.stop if reporter
         end


### PR DESCRIPTION
it hides the implementation on how metrics works internally with dropwizard
and exposes only a ruby API. reporters can be also configured via block using
the configuration methods as DSL methods.

fixes #14 