### PR TITLE
Datadog example

### DIFF
--- a/examples/datadog/.gitignore
+++ b/examples/datadog/.gitignore
@@ -1,0 +1,2 @@
+target
+Jars.lock

--- a/examples/datadog/Gemfile
+++ b/examples/datadog/Gemfile
@@ -1,0 +1,12 @@
+#-*- mode: ruby -*-
+
+source 'https://rubygems.org'
+
+gem 'leafy-metrics', :path => '../../leafy-metrics'
+
+group 'development' do
+  gem 'ruby-maven'
+  gem 'rake', '~> 10.2'
+end
+
+# vim: syntax=Ruby

--- a/examples/datadog/Mavenfile
+++ b/examples/datadog/Mavenfile
@@ -1,0 +1,22 @@
+#-*- mode: ruby -*-
+
+repository :id => 'bintray', :url => 'http://dl.bintray.com/lookout/systems'
+
+jar 'com.github.lookout:metrics-datadog:0.1.4'
+
+# dump Jars.lock
+################
+
+plugin_repository :id => 'sonatype-snapshots', :url => 'https://oss.sonatype.org/content/repositories/snapshots'
+
+repository :id => 'rubygems-releases', :url => 'http://rubygems-proxy.torquebox.org/releases'
+
+#properties 'jruby.plugins.version' => 
+jruby_plugin! :gem, '1.0.9-SNAPSHOT' do
+  
+  # duplicate dependency here and assume the local gem has the same
+  # dependencies as this one here
+  execute_goal 'jars-lock', :gems => ['leafy-metrics:0.3.0']
+end
+
+# vim: syntax=Ruby

--- a/examples/datadog/README.md
+++ b/examples/datadog/README.md
@@ -1,0 +1,16 @@
+# datadog gauge with tags example
+
+## setup
+
+execute with jruby
+
+    # installs all the gems
+    bundle install
+    # install all the jars and creates Jars.lock for the runtime
+    rmvn initialize
+
+## run example
+
+needs the datadog agent running and then
+
+    bundle exec ruby lib/metrics.rb

--- a/examples/datadog/lib/java_gauge.rb
+++ b/examples/datadog/lib/java_gauge.rb
@@ -1,0 +1,20 @@
+class JavaGauge
+  include Java::OrgCourseraMetricsDatadog::Tagged
+  include com.codahale.metrics.Gauge
+
+  def value
+    r = Time.now.usec
+    p r
+    r
+  end
+
+  def name
+    'leafy.demo.usec.java'
+  end
+
+  def tags
+    t = [Date::DAYNAMES[Time.now.wday]]
+    p t
+    t
+  end
+end

--- a/examples/datadog/lib/metrics.rb
+++ b/examples/datadog/lib/metrics.rb
@@ -1,0 +1,18 @@
+require 'leafy/metrics'
+require 'leafy/metrics/reporter'
+require_relative 'java_gauge'
+require_relative 'ruby_gauge'
+
+metrics = Leafy::Metrics::Registry.new
+my = metrics.register_gauge( 'leafy.demo.java.usec', JavaGauge.new )
+my = metrics.register_gauge( 'leafy.demo.ruby.usec', RubyGauge.new )
+
+transport =  Java::OrgCourseraMetricsDatadogTransport::UdpTransport::Builder.new.build
+
+reporter = metrics.reporter_builder( Java::OrgCourseraMetricsDatadog::DatadogReporter ).withTransport(transport).build
+
+reporter.start(1, Leafy::Metrics::Reporter::SECONDS)
+
+sleep 3
+
+reporter.stop

--- a/examples/datadog/lib/ruby_gauge.rb
+++ b/examples/datadog/lib/ruby_gauge.rb
@@ -1,0 +1,19 @@
+class RubyGauge < Leafy::Metrics::Gauge
+  include Java::OrgCourseraMetricsDatadog::Tagged
+
+  def value
+    r = Time.now.usec
+    p r
+    r
+  end
+
+  def name
+    'leafy.demo.usec.ruby'
+  end
+
+  def tags
+    t = [Date::DAYNAMES[Time.now.wday]]
+    p t
+    t
+  end
+end

--- a/examples/hellowarld/Gemfile.lock
+++ b/examples/hellowarld/Gemfile.lock
@@ -1,23 +1,3 @@
-PATH
-  remote: ../../leafy-health
-  specs:
-    leafy-health (0.2.1)
-      jar-dependencies (~> 0.1.8)
-
-PATH
-  remote: ../../leafy-metrics
-  specs:
-    leafy-metrics (0.2.1)
-      jar-dependencies (~> 0.1.8)
-
-PATH
-  remote: ../../leafy-rack
-  specs:
-    leafy-rack (0.2.1)
-      jar-dependencies (~> 0.1.8)
-      leafy-health (~> 0.2.0)
-      leafy-metrics (~> 0.2.0)
-
 GEM
   remote: https://rubygems.org/
   specs:

--- a/leafy-logger/leafy-logger.gemspec
+++ b/leafy-logger/leafy-logger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'jar io.dropwizard:dropwizard-configuration, 0.8.0-rc5, [ org.yaml:snakeyaml ]'
 
   s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
-  s.add_runtime_dependency 'leafy-metrics', '~> 0.2.0'
+  s.add_runtime_dependency 'leafy-metrics', "~> #{Leafy::Rack::VERSION}"
   s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'yard', '~> 0.8.7'
   s.add_development_dependency 'rake', '~> 10.2'

--- a/leafy-metrics/spec/registry_spec.rb
+++ b/leafy-metrics/spec/registry_spec.rb
@@ -50,7 +50,7 @@ describe Leafy::Metrics::Registry do
     obj = subject.register_gauge('me') do
       123
     end
-    expect(obj).to be_a(Leafy::Metrics::Registry::Gauge)
+    expect(obj).to be_a(Leafy::Metrics::Gauge)
     expect(subject.metrics.gauges['me']).to be obj
     expect(obj.value).to eq 123
 
@@ -62,7 +62,21 @@ describe Leafy::Metrics::Registry do
     obj = subject.register_gauge('me', Proc.new do
       123
     end )
-    expect(obj).to be_a(Leafy::Metrics::Registry::Gauge)
+    expect(obj).to be_a(Leafy::Metrics::Gauge)
+    expect(subject.metrics.gauges['me']).to be obj
+    expect(obj.value).to eq 123
+
+    subject.remove('me')
+    expect(subject.metrics.gauges).to be_empty
+  end
+
+  it 'registers and unregister com.codahale.metrics.Gauge' do
+    g = Leafy::Metrics::Gauge.new
+    def g.value
+      123
+    end
+    obj = subject.register_gauge('me', g)
+    expect(obj).to be_a(Leafy::Metrics::Gauge)
     expect(subject.metrics.gauges['me']).to be obj
     expect(obj.value).to eq 123
 

--- a/leafy-rack/leafy-rack.gemspec
+++ b/leafy-rack/leafy-rack.gemspec
@@ -19,8 +19,8 @@ Gem::Specification.new do |s|
   s.requirements << 'jar io.dropwizard.metrics:metrics-jvm, 3.1.0'
 
   s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
-  s.add_runtime_dependency 'leafy-metrics', '~> 0.2.0'
-  s.add_runtime_dependency 'leafy-health',  '~> 0.2.0'
+  s.add_runtime_dependency 'leafy-metrics', "~> #{Leafy::Rack::VERSION}"
+  s.add_runtime_dependency 'leafy-health',  "~> #{Leafy::Rack::VERSION}"
   s.add_development_dependency 'rspec', '~> 3.1.0'
   s.add_development_dependency 'yard', '~> 0.8.7'
   s.add_development_dependency 'rake', '~> 10.2'


### PR DESCRIPTION
this depends on PR #36 and uses the new gauge API to demonstrate how to use datadog-metrics tagged interface with datadog-metrics reporter