### PR TITLE
Leafy::Rack::Logger - introduce rack middleware to load logger

### DIFF
--- a/leafy-rack/leafy-rack.gemspec
+++ b/leafy-rack/leafy-rack.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
   s.add_runtime_dependency 'leafy-metrics', "~> #{Leafy::Rack::VERSION}"
   s.add_runtime_dependency 'leafy-health',  "~> #{Leafy::Rack::VERSION}"
+  s.add_runtime_dependency 'leafy-logger', "~> #{Leafy::Rack::VERSION}"
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'yard', '~> 0.8.7'
   s.add_development_dependency 'rake', '~> 10.2'

--- a/leafy-rack/lib/leafy/rack/logger.rb
+++ b/leafy-rack/lib/leafy/rack/logger.rb
@@ -1,0 +1,20 @@
+require 'leafy/logger/factory'
+
+module Leafy
+  module Rack
+    # Sets our Leafy logger as the rack logger to be used by other middleware / frameworks down
+    # the line. If you want your middleware to use this logger, we require that this runs first.
+    class Logger
+
+      def initialize(app, logger_name)
+        @app = app
+        @logger = Leafy::Logger::Factory.get_logger(logger_name)
+      end
+
+      def call(env)
+        env['rack.logger'] = @logger
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/leafy-rack/spec/logger_rack_spec.rb
+++ b/leafy-rack/spec/logger_rack_spec.rb
@@ -1,0 +1,20 @@
+require_relative 'setup'
+require 'leafy/rack/logger'
+require 'logger'
+
+describe Leafy::Rack::Logger do
+  let(:logger) { instance_double(::Logger) }
+  let(:logger_name) { 'some logger' }
+  let(:app) { double(call: nil) }
+  subject(:middleware) { described_class.new(app, logger_name) }
+
+  before { allow(Leafy::Logger::Factory).to receive(:get_logger).and_return(logger) }
+
+  describe '#call' do
+    let(:env) { { } }
+    it 'should set the logger' do
+      middleware.call(env)
+      expect(env['rack.logger']).to eq logger
+    end
+  end
+end


### PR DESCRIPTION
Sets rack.logger so that other middleware (or frameworks like Sinatra) use leafy.