### PR TITLE
use sematic versions for jar-dependencies runtime dependency

### DIFF
--- a/leafy-health/leafy-health.gemspec
+++ b/leafy-health/leafy-health.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << 'jar io.dropwizard.metrics:metrics-healthchecks, 3.1.0'
   s.requirements << 'jar io.dropwizard.metrics:metrics-jvm, 3.1.0'
 
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'yard', '~> 0.8.7'
   s.add_development_dependency 'rake', '~> 10.2'

--- a/leafy-logger/leafy-logger.gemspec
+++ b/leafy-logger/leafy-logger.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'jar io.dropwizard:dropwizard-logging, 0.8.0-rc5, [ joda-time:joda-time ]'
   s.requirements << 'jar io.dropwizard:dropwizard-configuration, 0.8.0-rc5, [ org.yaml:snakeyaml ]'
 
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
   s.add_runtime_dependency 'leafy-metrics', "~> #{Leafy::Logger::VERSION}"
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_development_dependency 'yard', '~> 0.8.7'

--- a/leafy-rack/leafy-rack.gemspec
+++ b/leafy-rack/leafy-rack.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.requirements << 'jar io.dropwizard.metrics:metrics-json, 3.1.0'
   s.requirements << 'jar io.dropwizard.metrics:metrics-jvm, 3.1.0'
 
-  s.add_runtime_dependency 'jar-dependencies', '~> 0.1.8'
+  s.add_runtime_dependency 'jar-dependencies', '~> 0.1'
   s.add_runtime_dependency 'leafy-metrics', "~> #{Leafy::Rack::VERSION}"
   s.add_runtime_dependency 'leafy-health',  "~> #{Leafy::Rack::VERSION}"
   s.add_runtime_dependency 'leafy-logger', "~> #{Leafy::Rack::VERSION}"


### PR DESCRIPTION
otherwise you can not use it with newer jar-dependencies.

[skip ci]